### PR TITLE
Enable debug info in materials in debug builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,8 +448,9 @@ if (FILAMENT_SUPPORTS_METAL)
     set(MATC_API_FLAGS ${MATC_API_FLAGS} -a metal)
 endif()
 
+# Disable optimizations and enable debug info (preserves names in SPIR-V)
 if (FILAMENT_DISABLE_MATOPT)
-    set(MATC_OPT_FLAGS -g)
+    set(MATC_OPT_FLAGS -gd)
 endif()
 
 set(MATC_BASE_FLAGS ${MATC_API_FLAGS} -p ${MATC_TARGET} ${MATC_OPT_FLAGS})

--- a/libs/gltfio/src/MaterialGenerator.cpp
+++ b/libs/gltfio/src/MaterialGenerator.cpp
@@ -325,6 +325,7 @@ static Material* createMaterial(Engine* engine, const MaterialKey& config, const
 
     if (!optimizeShaders) {
         builder.optimization(MaterialBuilder::Optimization::NONE);
+        builder.generateDebugInfo(true);
     }
 
     static_assert(std::tuple_size<UvMap>::value == 8, "Badly sized uvset.");


### PR DESCRIPTION
This lets you see highly readable GLSL when transpiling the generated
SPIRV back to GLSL, with the original variable names preserved.

For now this is only useful when using `matinfo`, but it will soon be
useful in `matdbg` too.