### PR TITLE
make blit() of all backend more similar

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -104,7 +104,7 @@ enum class TargetBufferFlags : uint32_t {
     ALL = COLOR_ALL | DEPTH | STENCIL       //!< Color, depth and stencil buffer selected.
 };
 
-inline TargetBufferFlags getTargetBufferFlagsAt(size_t index) noexcept {
+inline constexpr TargetBufferFlags getTargetBufferFlagsAt(size_t index) noexcept {
     if (index == 0u) return TargetBufferFlags::COLOR0;
     if (index == 1u) return TargetBufferFlags::COLOR1;
     if (index == 2u) return TargetBufferFlags::COLOR2;

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1037,6 +1037,10 @@ void MetalDriver::blit(TargetBufferFlags buffers,
     auto srcTarget = handle_cast<MetalRenderTarget>(src);
     auto dstTarget = handle_cast<MetalRenderTarget>(dst);
 
+    ASSERT_PRECONDITION(
+            !(buffers & (TargetBufferFlags::COLOR_ALL & ~TargetBufferFlags::COLOR0)),
+            "Blitting only supports COLOR0");
+
     ASSERT_PRECONDITION(srcRect.left >= 0 && srcRect.bottom >= 0 &&
                         dstRect.left >= 0 && dstRect.bottom >= 0,
             "Source and destination rects must be positive.");
@@ -1069,23 +1073,8 @@ void MetalDriver::blit(TargetBufferFlags buffers,
     args.destination.region = dstRegion;
 
     if (any(buffers & TargetBufferFlags::COLOR_ALL)) {
-        size_t srcAttachIndex = 0;
-        if (any(buffers & TargetBufferFlags::COLOR0)) {
-            srcAttachIndex = 0;
-        }
-        if (any(buffers & TargetBufferFlags::COLOR1)) {
-            srcAttachIndex = 1;
-        }
-        if (any(buffers & TargetBufferFlags::COLOR2)) {
-            srcAttachIndex = 2;
-        }
-        if (any(buffers & TargetBufferFlags::COLOR3)) {
-            srcAttachIndex = 3;
-        }
-
-        MetalRenderTarget::Attachment srcColorAttachment = srcTarget->getReadColorAttachment(srcAttachIndex);
-
-        // We always blit to the COLOR0 attachment.
+        // We always blit from/to the COLOR0 attachment.
+        MetalRenderTarget::Attachment srcColorAttachment = srcTarget->getReadColorAttachment(0);
         MetalRenderTarget::Attachment dstColorAttachment = dstTarget->getDrawColorAttachment(0);
 
         if (srcColorAttachment && dstColorAttachment) {

--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -93,7 +93,7 @@ constexpr inline GLuint getComponentCount(backend::ElementType type) noexcept {
 
 constexpr inline GLbitfield getAttachmentBitfield(backend::TargetBufferFlags flags) noexcept {
     GLbitfield mask = 0;
-    if (any(flags & backend::TargetBufferFlags::COLOR)) {
+    if (any(flags & backend::TargetBufferFlags::COLOR_ALL)) {
         mask |= (GLbitfield)GL_COLOR_BUFFER_BIT;
     }
     if (any(flags & backend::TargetBufferFlags::DEPTH)) {

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2318,6 +2318,11 @@ void OpenGLDriver::resolvePass(ResolveAction action, GLRenderTarget const* rt,
     const TargetBufferFlags resolve = rt->gl.resolve & ~discardFlags;
     GLbitfield mask = getAttachmentBitfield(resolve);
     if (UTILS_UNLIKELY(mask)) {
+
+        // we can only resolve COLOR0 at the moment
+        assert_invariant(!(rt->targets &
+                (TargetBufferFlags::COLOR_ALL & ~TargetBufferFlags::COLOR0)));
+
         GLint read = rt->gl.fbo_read;
         GLint draw = rt->gl.fbo;
         if (action == ResolveAction::STORE) {
@@ -3029,6 +3034,14 @@ void OpenGLDriver::blit(TargetBufferFlags buffers,
         // reverse-resolve, but that wouldn't buy us anything.
         GLRenderTarget const* s = handle_cast<GLRenderTarget const*>(src);
         GLRenderTarget const* d = handle_cast<GLRenderTarget const*>(dst);
+
+        // blit operations are only supported from RenderTargets that have only COLOR0 (or
+        // no color buffer at all)
+        assert_invariant(
+                !(s->targets & (TargetBufferFlags::COLOR_ALL & ~TargetBufferFlags::COLOR0)));
+
+        assert_invariant(
+                !(d->targets & (TargetBufferFlags::COLOR_ALL & ~TargetBufferFlags::COLOR0)));
 
         // With GLES 3.x, GL_INVALID_OPERATION is generated if the value of GL_SAMPLE_BUFFERS
         // for the draw buffer is greater than zero. This works with OpenGL, so we want to


### PR DESCRIPTION
This all started because the gl backend version of blit() didn't
handle color attachments other than COLOR0 *AND* would actually
corrupt the destination attachments other than COLOR0 if present. 
This is due to how very stateful the gl API is.

Since this is a case we're not running into currently, the GL backend will
now assert in that case.

Updated the Vulkan and Metal backends to also reject blits where
color buffers other than COLOR0 are requested.

Ultimately, we need to change entirely our backend blit API so it 
is less GL centric.