### PR TITLE
[ORG] RU-MAKEAPP: improve how the structure pass commands are generated

### DIFF
--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -357,8 +357,7 @@ Handle<HwProgram> FMaterial::getProgramSlow(uint8_t variantKey) const noexcept {
     }
 }
 
-Handle<HwProgram> FMaterial::getSurfaceProgramSlow(uint8_t variantKey)
-    const noexcept {
+Handle<HwProgram> FMaterial::getSurfaceProgramSlow(uint8_t variantKey) const noexcept {
     // filterVariant() has already been applied in generateCommands(), shouldn't be needed here
     // if we're unlit, we don't have any bits that correspond to lit materials
     assert_invariant( variantKey == Variant::filterVariant(variantKey, isVariantLit()) );


### PR DESCRIPTION
the code generating the commands for the structure pass (called DEPTH)
in the code was different that from the color. This made sense, but 
isn't great from an architectural standpoint.
Moreover, the special filtering flags DEPTH_FILTER_*_OBJECTS were
useless because part of their functionality was handled in the DEPTH
code directly.

Instead, we now generate the DEPTH commands the same way than we do for
COLOR, but we honor the DEPTH_FILTER_*_OBJECTS flags properly.